### PR TITLE
Add a WORKSPACE with name, to satisfy bazel 0.2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ Add the following code to your `WORKSPACE` file:
 
 ```python
 git_repository(
-    name = "bazel_git_repositories",
+    name = "com_github_nelhage_bazel_git_repositories",
     remote = "https://github.com/nelhage/bazel_git_repositories",
     tag = "v2",
 )
 
 load(
-    "@bazel_git_repositories//:repositories.bzl",
+    "@com_github_nelhage_bazel_git_repositories//:repositories.bzl",
     "new_native_git_repository",
     "native_git_repository",
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,1 @@
+workspace(name = "com_github_nelhage_bazel_git_repositories")


### PR DESCRIPTION
I think the preferred bazel style in naming repos is the reverse domain name approach, so I added that here.

Tested this and it squashes the warning.
