### PR TITLE
Add a name to new_git repos WORKSPACE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+test/bazel-*

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -27,6 +27,7 @@ git clean -xdf
 
 def _new_native_git_repository_implementation(ctx):
   _clone_or_update(ctx)
+  ctx.file('WORKSPACE', "workspace(name = \"{name}\")\n".format(name=ctx.name))
   if ctx.attr.build_file:
     ctx.symlink(ctx.attr.build_file, 'BUILD')
   else:

--- a/test/WORKSPACE
+++ b/test/WORKSPACE
@@ -1,0 +1,25 @@
+workspace(name = "test")
+
+local_repository(name = "com_github_nelhage_bazel_git_repositories",
+                 path = "../")
+
+load(
+    "@com_github_nelhage_bazel_git_repositories//:repositories.bzl",
+    "new_native_git_repository",
+    "native_git_repository",
+)
+
+new_native_git_repository(
+    name = "io_bazel_rules_scala",
+    remote = "https://github.com/bazelbuild/rules_scala.git",
+    commit = "7b891adb975b4e3e6569b763d39ab6e9234196c9",
+    build_file_contents = """
+filegroup(
+  name="readme",
+  srcs=["README.md"],
+  visibility=["//visibility:public"],
+  )
+"""
+)
+
+

--- a/test/src/BUILD
+++ b/test/src/BUILD
@@ -1,0 +1,4 @@
+genrule(name = "echo",
+        srcs = ["@io_bazel_rules_scala//:readme"],
+        outs = ["localREADME.md"],
+        cmd = "cat $(locations @io_bazel_rules_scala//:readme) > $@")


### PR DESCRIPTION
We added a name to this repo, but the new repos it creates don't have names, so that gives warnings that will be errors.

This fixes it and tests it.

We should wire up travis for this (see bazelbuild/rules_scala for an example of a travis setup with bazel).
