### PR TITLE
Don't fetch unless reset fails

### DIFF
--- a/repositories.bzl
+++ b/repositories.bzl
@@ -14,8 +14,7 @@ if ! ( cd '{dir}' && git rev-parse --git-dir ) >/dev/null 2>&1; then
   git clone '{remote}' '{dir}'
 fi
 cd '{dir}'
-git fetch
-git reset --hard {ref}
+git reset --hard {ref} || (git fetch && git reset --hard {ref})
 git clean -xdf
   """.format(
     dir=ctx.path("."),


### PR DESCRIPTION
I think most builds won't change shas, so this should be a win (in that we should be able to build without network access if the sha is not advanced).
